### PR TITLE
Disable special chars in RDS password

### DIFF
--- a/ecs-cluster/keycloak.tf
+++ b/ecs-cluster/keycloak.tf
@@ -8,7 +8,8 @@ locals {
 }
 
 resource "random_password" "db-password" {
-  length = 20
+  length  = 20
+  special = false
 }
 
 resource "random_string" "initial-keycloak-password" {


### PR DESCRIPTION
Otherwise you may get
`Error: Error creating DB Instance: InvalidParameterValue: The parameter MasterUserPassword is not a valid password. Only printable ASCII characters besides '/', '@', '"', ' ' may be used.`