### PR TITLE
Build container in GH workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,9 @@
 ---
 
 name: CI
-'on':
+on:
   push:
-    branches:
-      - '*'
-    paths-ignore:
-      - '**/*.md'
+  pull_request:
 
 jobs:
 

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,51 @@
+---
+name: Container build
+on:
+  push:
+    paths:
+      - "container/**"
+      - .github/workflows/container.yml
+      # Note this should also be built on tags
+  pull_request:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+
+  container-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        if: >
+          github.event_name == 'push' &&
+          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # https://github.com/docker/metadata-action
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # https://github.com/docker/build-push-action
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: ./container
+          push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Keycloak on ECS with RDS
 [![CI](https://github.com/hic-infra/ecs-keycloak/actions/workflows/ci.yml/badge.svg)](https://github.com/hic-infra/ecs-keycloak/actions/workflows/ci.yml)
+[![Container build](https://github.com/manics/ecs-keycloak/actions/workflows/container.yml/badge.svg)](https://github.com/manics/ecs-keycloak/actions/workflows/container.yml)
 
 This is a demo of running Keycloak on ECS with an RDS (PostgreSQL) database.
 


### PR DESCRIPTION
The container will be pushed to GHCR for tags, and also pushed to `main` which modify `container/**`. We may want to disable the latter or have some sort of cleanup if we hit the GHCR repository storage limit.