### PR TITLE
Encrypt RDS postgres Database

### DIFF
--- a/ecs-cluster/keycloak.tf
+++ b/ecs-cluster/keycloak.tf
@@ -175,29 +175,6 @@ resource "aws_db_subnet_group" "keycloak" {
   subnet_ids = module.vpc.private_subnets
 }
 
-resource "aws_db_instance" "keycloak-old" {
-  identifier        = "keycloak"
-  instance_class    = "db.t3.micro"
-  allocated_storage = 5
-  engine            = "postgres"
-  # TODO: try serverless?
-  # engine = "aurora-postgresql"
-  # auto_minor_version_upgrade defaults to True, so this will be auto-upgraded to the  most recent 14.*
-  engine_version         = "14"
-  db_name                = var.db-name
-  username               = var.db-username
-  password               = random_password.db-password.result
-  db_subnet_group_name   = aws_db_subnet_group.keycloak.name
-  vpc_security_group_ids = [aws_security_group.rds.id]
-  parameter_group_name   = aws_db_parameter_group.keycloak.name
-  publicly_accessible    = false
-  skip_final_snapshot    = true
-
-  lifecycle {
-    prevent_destroy = true
-  }
-}
-
 resource "aws_db_instance" "keycloak" {
   identifier            = "keycloak-1"
   instance_class        = var.db-instance-type

--- a/ecs-cluster/keycloak.tf
+++ b/ecs-cluster/keycloak.tf
@@ -193,6 +193,7 @@ resource "aws_db_instance" "keycloak" {
   publicly_accessible    = false
   skip_final_snapshot    = true
 
+  snapshot_identifier = var.db-snapshot-identifier
   lifecycle {
     prevent_destroy = true
   }
@@ -327,9 +328,9 @@ resource "aws_ecs_service" "keycloak" {
   name                               = "${var.name}-service"
   cluster                            = aws_ecs_cluster.ecs.id
   task_definition                    = aws_ecs_task_definition.keycloak.arn
-  desired_count                      = 1
-  deployment_minimum_healthy_percent = 100
-  deployment_maximum_percent         = 200
+  desired_count                      = var.desired-count
+  deployment_minimum_healthy_percent = (var.desired-count < 1) ? 0 : 100
+  deployment_maximum_percent         = max(100, var.desired-count * 200)
   launch_type                        = "FARGATE"
   scheduling_strategy                = "REPLICA"
 

--- a/ecs-cluster/variables.tf
+++ b/ecs-cluster/variables.tf
@@ -39,6 +39,13 @@ variable "db-snapshot-identifier" {
   default     = null
   description = "If creating a new DB restore from this snapshot"
 }
+
+variable "db-instance-type" {
+  type        = string
+  default     = "db.t3.micro"
+  description = "RDS instance type: https://aws.amazon.com/rds/instance-types/"
+}
+
 variable "loadbalancer-certificate-arn" {
   type        = string
   description = "ARN of the ACM certificate to use for the load balancer"

--- a/ecs-cluster/variables.tf
+++ b/ecs-cluster/variables.tf
@@ -34,6 +34,11 @@ variable "db-username" {
   description = "Keycloak DB username"
 }
 
+variable "db-snapshot-identifier" {
+  type        = string
+  default     = null
+  description = "If creating a new DB restore from this snapshot"
+}
 variable "loadbalancer-certificate-arn" {
   type        = string
   description = "ARN of the ACM certificate to use for the load balancer"
@@ -43,6 +48,12 @@ variable "keycloak-hostname" {
   type        = string
   default     = ""
   description = "Keycloak hostname, if empty uses the load-balancer hostname"
+}
+
+variable "desired-count" {
+  type        = number
+  description = "Number of Keycloak containers to run, set to 0 for DB maintenance"
+  default     = 1
 }
 
 variable "default-tags" {


### PR DESCRIPTION
Encrypt RDS postgres Database, also turns on automatic snapshots (they're not automatically enabled)
AWSCLOU-321

**⚠️ This must be applied manually one commit at a time since you can't encrypt a database in-place ⚠️**

1. Set AWS profile and terraform vars file
```
export AWS_PROFILE=<aws-profile>
VARS_FILE=<secret-config>.tfvars
```

2. Checkout commit 30829dcaaadb631595982b4a1ecfd9260ef8ab82
3. Stop keycloak
```
cd ecs-cluster
terraform apply -var-file=$VARS_FILE -var desired-count=0
```

4. Snapshot keycloak DB, and create an encrypted copy. If KMS `alias/aws/rds` doesn't exist create the encrypted snapshot using the AWS web console.
```
DB_INSTANCE=keycloak
SNAPSHOT_NAME=keycloak-20221201

aws rds create-db-snapshot --db-instance-identifier $DB_INSTANCE --db-snapshot-identifier $SNAPSHOT_NAME

aws rds copy-db-snapshot --source-db-snapshot-identifier $SNAPSHOT_NAME --target-db-snapshot-identifier $SNAPSHOT_NAME-encrypted --kms-key-id alias/aws/rds
```

5. Checkout commit 2040ae9571af384847a6d3b5a0c85bc2bd15a88a
6. Rename the existing Terraform DB resource from `keycloak` to `keycloak-old` and deploy new keycloak DB. **Note: check that the plan creates a new DB but does not destroy the old one**
```
terraform state mv aws_db_instance.keycloak aws_db_instance.keycloak-old

terraform apply -var-file=$VARS_FILE -var desired-count=0 -var db-snapshot-identifier=$SNAPSHOT_NAME-encrypted
```

7. Restart keycloak
```
terraform apply -var-file=$VARS_FILE
```

8. Check keycloak is working! 

9. Checkout commit 2f483a6a8e854fc4c32ed3748bb49b0c1d32ab30
10. Delete the old keycloak DB
```
terraform apply -var-file=$VARS_FILE
```

11. Delete the unencrypted snapshot
```
aws rds delete-db-snapshot --db-snapshot-identifier $SNAPSHOT_NAME
```

I think we should tag this as `1.0.0-beta.2`