### PR TITLE
Optionally use existing VPC. Upgrade Keycloak to 24.0.2

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,6 +1,6 @@
 # https://www.keycloak.org/server/containers
 
-ARG KEYCLOAK_VERSION=22.0.5
+ARG KEYCLOAK_VERSION=23.0.4
 FROM quay.io/keycloak/keycloak:$KEYCLOAK_VERSION as builder
 
 ENV KC_DB=postgres

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -5,6 +5,7 @@ FROM quay.io/keycloak/keycloak:$KEYCLOAK_VERSION as builder
 
 ENV KC_DB=postgres
 ENV KC_HOSTNAME=localhost
+ENV KC_HEALTH_ENABLED=true
 
 RUN /opt/keycloak/bin/kc.sh build
 

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,6 +1,6 @@
 # https://www.keycloak.org/server/containers
 
-ARG KEYCLOAK_VERSION=24.0.0
+ARG KEYCLOAK_VERSION=24.0.2
 FROM quay.io/keycloak/keycloak:$KEYCLOAK_VERSION as builder
 
 ENV KC_DB=postgres

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,6 +1,6 @@
 # https://www.keycloak.org/server/containers
 
-ARG KEYCLOAK_VERSION=23.0.4
+ARG KEYCLOAK_VERSION=24.0.0
 FROM quay.io/keycloak/keycloak:$KEYCLOAK_VERSION as builder
 
 ENV KC_DB=postgres

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -6,4 +6,10 @@ set -eu
 cd /opt/keycloak
 keytool -genkeypair -storepass password -storetype PKCS12 -keyalg RSA -keysize 2048 -dname "CN=$KC_HOSTNAME" -alias server -ext "SAN:c=DNS:$KC_HOSTNAME,DNS:localhost,IP:127.0.0.1" -keystore conf/server.keystore
 
+# If KC_DB has been overridden then need to rebuild the config
+if [ "$KC_DB" != postgres ]; then
+  echo "KC_DB has been overridden to $KC_DB, rebuilding"
+  /opt/keycloak/bin/kc.sh build
+fi
+
 exec /opt/keycloak/bin/kc.sh "$@"

--- a/ecs-cluster/keycloak.tf
+++ b/ecs-cluster/keycloak.tf
@@ -104,7 +104,7 @@ resource "aws_alb_target_group" "keycloak" {
     protocol            = "HTTPS"
     matcher             = "200"
     timeout             = "5"
-    path                = "/"
+    path                = "/health"
     unhealthy_threshold = "2"
   }
 }
@@ -321,6 +321,10 @@ resource "aws_ecs_task_definition" "keycloak" {
       {
         name  = "KC_PROXY_HEADERS"
         value = "xforwarded"
+      },
+      {
+        name  = "KC_HEALTH_ENABLED"
+        value = "true"
       },
       {
         name  = "KC_LOG_LEVEL"

--- a/ecs-cluster/keycloak.tf
+++ b/ecs-cluster/keycloak.tf
@@ -3,6 +3,10 @@ data "aws_caller_identity" "current" {}
 locals {
   container-port    = 8443
   keycloak-hostname = var.keycloak-hostname == "" ? aws_lb.keycloak.dns_name : var.keycloak-hostname
+
+  vpc_id          = var.vpc-id == "" ? module.vpc[0].vpc_id : var.vpc-id
+  public_subnets  = var.public-subnets == [] ? module.vpc[0].public_subnets : var.public-subnets
+  private_subnets = var.private-subnets == [] ? module.vpc[0].private_subnets : var.private-subnets
 }
 
 resource "random_password" "db-password" {
@@ -18,7 +22,7 @@ resource "random_string" "initial-keycloak-password" {
 
 resource "aws_security_group" "rds" {
   name   = "${var.name}-sg-rds"
-  vpc_id = module.vpc.vpc_id
+  vpc_id = local.vpc_id
 
   ingress {
     from_port       = 5432
@@ -30,7 +34,7 @@ resource "aws_security_group" "rds" {
 
 resource "aws_security_group" "alb" {
   name   = "${var.name}-sg-alb"
-  vpc_id = module.vpc.vpc_id
+  vpc_id = local.vpc_id
 
   ingress {
     protocol    = "tcp"
@@ -56,7 +60,7 @@ resource "aws_security_group" "alb" {
 
 resource "aws_security_group" "ecs-task-keycloak" {
   name   = "${var.name}-sg-task-keycloak"
-  vpc_id = module.vpc.vpc_id
+  vpc_id = local.vpc_id
 
   ingress {
     protocol        = "tcp"
@@ -80,7 +84,7 @@ resource "aws_lb" "keycloak" {
   internal           = false
   load_balancer_type = "application"
   security_groups    = [aws_security_group.alb.id]
-  subnets            = module.vpc.public_subnets
+  subnets            = local.public_subnets
 
   enable_deletion_protection = true
 
@@ -91,7 +95,7 @@ resource "aws_alb_target_group" "keycloak" {
   name        = "${var.name}-tg"
   port        = 443
   protocol    = "HTTPS"
-  vpc_id      = module.vpc.vpc_id
+  vpc_id      = local.vpc_id
   target_type = "ip"
 
   health_check {
@@ -172,7 +176,7 @@ resource "aws_db_parameter_group" "keycloak" {
 
 resource "aws_db_subnet_group" "keycloak" {
   name       = "${var.name}-keycloak"
-  subnet_ids = module.vpc.private_subnets
+  subnet_ids = local.private_subnets
 }
 
 resource "aws_db_instance" "keycloak" {
@@ -352,7 +356,7 @@ resource "aws_ecs_service" "keycloak" {
       aws_security_group.rds.id,
       aws_security_group.ecs-task-keycloak.id
     ]
-    subnets = module.vpc.private_subnets
+    subnets = local.private_subnets
     # TODO: Setting this to False means the image can't be pulled. Why? It works in K8s.
     # assign_public_ip = true
   }

--- a/ecs-cluster/keycloak.tf
+++ b/ecs-cluster/keycloak.tf
@@ -315,10 +315,12 @@ resource "aws_ecs_task_definition" "keycloak" {
         name  = "KC_HOSTNAME"
         value = local.keycloak-hostname
       },
-      # https://github.com/keycloak/keycloak/issues/13114
+      # https://www.keycloak.org/server/reverseproxy
+      # AWS load balancers set X-Forwarded not Forwarded
+      # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/x-forwarded-headers.html
       {
-        name  = "KC_PROXY"
-        value = "reencrypt"
+        name  = "KC_PROXY_HEADERS"
+        value = "xforwarded"
       },
       # {
       #   name  = "KC_LOG_LEVEL"

--- a/ecs-cluster/keycloak.tf
+++ b/ecs-cluster/keycloak.tf
@@ -323,10 +323,6 @@ resource "aws_ecs_task_definition" "keycloak" {
         value = "xforwarded"
       },
       {
-        name  = "KC_HEALTH_ENABLED"
-        value = "true"
-      },
-      {
         name  = "KC_LOG_LEVEL"
         value = var.keycloak-loglevel
       },

--- a/ecs-cluster/keycloak.tf
+++ b/ecs-cluster/keycloak.tf
@@ -322,10 +322,10 @@ resource "aws_ecs_task_definition" "keycloak" {
         name  = "KC_PROXY_HEADERS"
         value = "xforwarded"
       },
-      # {
-      #   name  = "KC_LOG_LEVEL"
-      #   value = "debug"
-      # }
+      {
+        name  = "KC_LOG_LEVEL"
+        value = var.keycloak-loglevel
+      },
     ]
     portMappings = [{
       protocol      = "tcp"

--- a/ecs-cluster/terraform.tf
+++ b/ecs-cluster/terraform.tf
@@ -1,8 +1,3 @@
-terraform {
-  backend "s3" {
-  }
-}
-
 provider "aws" {
   region = var.region
 

--- a/ecs-cluster/variables.tf
+++ b/ecs-cluster/variables.tf
@@ -22,6 +22,24 @@ variable "lb-cidr-blocks-in" {
   description = "CIDR blocks to allow access to the load balancer"
 }
 
+variable "vpc-id" {
+  type        = string
+  default     = ""
+  description = "VPC ID, if empty creates a new VPC"
+}
+
+variable "public-subnets" {
+  type        = list(string)
+  default     = []
+  description = "Public subnet IDs, must be defined if vpc-id is provided"
+}
+
+variable "private-subnets" {
+  type        = list(string)
+  default     = []
+  description = "Private subnet IDs, must be defined if vpc-id is provided"
+}
+
 variable "db-name" {
   type        = string
   default     = "keycloak"

--- a/ecs-cluster/variables.tf
+++ b/ecs-cluster/variables.tf
@@ -75,6 +75,12 @@ variable "keycloak-hostname" {
   description = "Keycloak hostname, if empty uses the load-balancer hostname"
 }
 
+variable "keycloak-loglevel" {
+  type        = string
+  default     = "INFO"
+  description = "Keycloak log-level e.g. DEBUG."
+}
+
 variable "desired-count" {
   type        = number
   description = "Number of Keycloak containers to run, set to 0 for DB maintenance"

--- a/ecs-cluster/vpc.tf
+++ b/ecs-cluster/vpc.tf
@@ -3,6 +3,7 @@ data "aws_availability_zones" "available" {}
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "5.2.0"
+  count   = var.vpc-id == "" ? 1 : 0
 
   name                 = "${var.name}-vpc"
   cidr                 = "10.199.0.0/16"
@@ -17,4 +18,11 @@ module "vpc" {
   manage_default_route_table    = false
   manage_default_network_acl    = false
   map_public_ip_on_launch       = true
+}
+
+# Backwards compatibility with existing deployments
+# https://developer.hashicorp.com/terraform/language/modules/develop/refactoring#enabling-count-or-for_each-for-a-resource
+moved {
+  from = module.vpc
+  to   = module.vpc[0]
 }


### PR DESCRIPTION
Todo: 

- [x] configure handling of `Forwarded` / `X-Forwarded` headers:
    - https://www.keycloak.org/server/reverseproxy#_configure_the_reverse_proxy
    - https://docs.aws.amazon.com/elasticloadbalancing/latest/application/x-forwarded-headers.html

This also exposes a new public `/health` endpoint https://www.keycloak.org/server/all-config#category-health