### PR TITLE
Add `terraform {backend s3}` back

### DIFF
--- a/ecs-cluster/terraform.tf
+++ b/ecs-cluster/terraform.tf
@@ -1,3 +1,10 @@
+# The Terraform state should be stored in S3, but you must configure the S3 bucket/prefix separately.
+# See example.s3.tfbackend
+terraform {
+  backend "s3" {
+  }
+}
+
 provider "aws" {
   region = var.region
 


### PR DESCRIPTION
I thought we could easily decouple the requirement for the state to be stored in S3 so that it could be entirely in the private deployment repo, but it looks like it's not as easy as I thought. It's still possible, but to avoid unnecessary breakages let's just mandate it here instead.

Added a comment so I remember next time.

Partially reverts commit dc8987cae95e46384c69e62aedd4ac6de0498fe7.