### PR TITLE
Fix empty check of `var.{public,private}-subnets`, delay health check, 2.0.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-## 2.0.0-beta.1 - In progress
+## 2.0.0-beta.3 - In progress
 
-([full changelog](https://github.com/hic-infra/ecs-keycloak/compare/1.0.0...2.0.0-beta.1))
+([full changelog](https://github.com/hic-infra/ecs-keycloak/compare/1.0.0...2.0.0-beta.3))
 
+- Fix empty check of `var.{public,private}-subnets`, delay health check, 2.0.0-beta.3 [#16](https://github.com/hic-infra/ecs-keycloak/pull/16)
+- Release 2.0.0-beta.2 [#15](https://github.com/hic-infra/ecs-keycloak/pull/15)
 - Add `terraform {backend s3}` back [#14](https://github.com/hic-infra/ecs-keycloak/pull/14)
 - Release 2.0.0-beta.1 [#13](https://github.com/hic-infra/ecs-keycloak/pull/13)
 - Optionally use existing VPC. Upgrade Keycloak to 24.0.2 [#12](https://github.com/hic-infra/ecs-keycloak/pull/12)

--- a/ecs-cluster/keycloak.tf
+++ b/ecs-cluster/keycloak.tf
@@ -5,8 +5,8 @@ locals {
   keycloak-hostname = var.keycloak-hostname == "" ? aws_lb.keycloak.dns_name : var.keycloak-hostname
 
   vpc_id          = var.vpc-id == "" ? module.vpc[0].vpc_id : var.vpc-id
-  public_subnets  = length(var.public-subnets) == 0 ? module.vpc[0].public_subnets : var.public-subnets
-  private_subnets = length(var.private-subnets) == 0 ? module.vpc[0].private_subnets : var.private-subnets
+  public_subnets  = coalescelist(var.public-subnets, module.vpc[0].public_subnets)
+  private_subnets = coalescelist(var.private-subnets, module.vpc[0].private_subnets)
 }
 
 resource "random_password" "db-password" {

--- a/ecs-cluster/keycloak.tf
+++ b/ecs-cluster/keycloak.tf
@@ -5,8 +5,8 @@ locals {
   keycloak-hostname = var.keycloak-hostname == "" ? aws_lb.keycloak.dns_name : var.keycloak-hostname
 
   vpc_id          = var.vpc-id == "" ? module.vpc[0].vpc_id : var.vpc-id
-  public_subnets  = var.public-subnets == [] ? module.vpc[0].public_subnets : var.public-subnets
-  private_subnets = var.private-subnets == [] ? module.vpc[0].private_subnets : var.private-subnets
+  public_subnets  = length(var.public-subnets) == 0 ? module.vpc[0].public_subnets : var.public-subnets
+  private_subnets = length(var.private-subnets) == 0 ? module.vpc[0].private_subnets : var.private-subnets
 }
 
 resource "random_password" "db-password" {

--- a/ecs-cluster/keycloak.tf
+++ b/ecs-cluster/keycloak.tf
@@ -5,8 +5,8 @@ locals {
   keycloak-hostname = var.keycloak-hostname == "" ? aws_lb.keycloak.dns_name : var.keycloak-hostname
 
   vpc_id          = var.vpc-id == "" ? module.vpc[0].vpc_id : var.vpc-id
-  public_subnets  = coalescelist(var.public-subnets, module.vpc[0].public_subnets)
-  private_subnets = coalescelist(var.private-subnets, module.vpc[0].private_subnets)
+  public_subnets  = length(var.public-subnets) == 0 ? module.vpc[0].public_subnets : var.public-subnets
+  private_subnets = length(var.private-subnets) == 0 ? module.vpc[0].private_subnets : var.private-subnets
 }
 
 resource "random_password" "db-password" {

--- a/ecs-cluster/keycloak.tf
+++ b/ecs-cluster/keycloak.tf
@@ -369,6 +369,9 @@ resource "aws_ecs_service" "keycloak" {
     container_port   = local.container-port
   }
 
+  # Java applications can be very slow to start
+  health_check_grace_period_seconds = 180
+
   # lifecycle {
   #   ignore_changes = [desired_count]
   # }

--- a/ecs-cluster/variables.tf
+++ b/ecs-cluster/variables.tf
@@ -12,7 +12,7 @@ variable "region" {
 
 variable "keycloak-image" {
   type        = string
-  default     = "ghcr.io/hic-infra/ecs-keycloak:2.0.0-beta.2"
+  default     = "ghcr.io/hic-infra/ecs-keycloak:2.0.0-beta.3"
   description = "Keycloak image including registry"
 }
 


### PR DESCRIPTION
`var.public-subnets == []` returns false when the default value of `public-subnets` is `[]` because it's treated as `tolist([])`.

The startup time of this container seems to cross the boundary of where ECS considers the task as unhealthy due to multiple health checks failing, so this adds a 3 minutes delay before checking the health of the task.

Also prepares another beta release, 2.0.0-beta.3.