### PR TITLE
Update keycloak 26.0.5

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,6 +1,6 @@
 # https://www.keycloak.org/server/containers
 
-ARG KEYCLOAK_VERSION=25.0.1
+ARG KEYCLOAK_VERSION=26.0.5
 FROM quay.io/keycloak/keycloak:$KEYCLOAK_VERSION as builder
 
 ENV KC_DB=postgres

--- a/ecs-cluster/keycloak.tf
+++ b/ecs-cluster/keycloak.tf
@@ -325,7 +325,7 @@ resource "aws_ecs_task_definition" "keycloak" {
       },
       # https://www.keycloak.org/server/reverseproxy
       # AWS load balancers set X-Forwarded not Forwarded
-      # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/x-forwarded-headers.html
+      # https://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/how-elastic-load-balancing-works.html
       {
         name  = "KC_PROXY_HEADERS"
         value = "xforwarded"


### PR DESCRIPTION
Release notes https://www.keycloak.org/docs/latest/release_notes/index.html
Upgrade guide https://www.keycloak.org/docs/26.0.5/upgrading/

To be tagged as `2.1.0`

https://hicservices.atlassian.net/browse/CM-334