### PR TITLE
Keycloak 26.1.1

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+
+  # Bump dockerfile FROM
+  - package-ecosystem: docker
+    directory: /container
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       IMAGE_NAME: ${{ github.repository }}
       # Set this to `main` to rebuild container on every push to main
       # instead of just tags
-      PUBLISH_BRANCH: ""
+      PUBLISH_BRANCH: main
       PLATFORMS: linux/amd64,linux/arm64
     steps:
       - name: Checkout

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,7 +1,5 @@
 # https://www.keycloak.org/server/containers
-
-ARG KEYCLOAK_VERSION=26.0.5
-FROM quay.io/keycloak/keycloak:$KEYCLOAK_VERSION as builder
+FROM quay.io/keycloak/keycloak:26.1.1
 
 ENV KC_DB=postgres
 ENV KC_HOSTNAME=localhost


### PR DESCRIPTION
Add dependabot for automatic updates, though unfortunately we don't have automated functional tests.

Build and publish the container built from the `main` branch to make testing easier (currently only tags are published).

https://hicservices.atlassian.net/browse/CM-383