### PR TITLE
Add access logging for load-balancer

### DIFF
--- a/ecs-cluster/keycloak.tf
+++ b/ecs-cluster/keycloak.tf
@@ -158,6 +158,11 @@ resource "aws_lb" "keycloak" {
     prefix  = "access-logs"
     enabled = true
   }
+
+  depends_on = [
+    # ELB writes a test file to bucket/access-logs so the policy must be in place
+    aws_s3_bucket_policy.alb-logs
+  ]
 }
 
 resource "aws_alb_target_group" "keycloak" {

--- a/ecs-cluster/variables.tf
+++ b/ecs-cluster/variables.tf
@@ -87,6 +87,24 @@ variable "desired-count" {
   default     = 1
 }
 
+variable "loadbalancer-logging-iam-principal" {
+  type        = map(string)
+  description = "IAM principal type and identifier for the elastic load balancer logger. This is complicated, see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html#attach-bucket-policy"
+
+  # For eu-west-2 this is a hard-coded AWS account ID belonging to AWS
+  # and not Service: logdelivery.elasticloadbalancing.amazonaws.com
+  default = {
+    type       = "AWS"
+    identifier = "arn:aws:iam::652711504416:root"
+  }
+}
+
+variable "expire-access-logs-days" {
+  type        = number
+  description = "Automatically delete access logs after this number of days"
+  default     = 3653
+}
+
 variable "default-tags" {
   type = map(any)
   default = {


### PR DESCRIPTION
This adds [Elastic Load Balancing access logging](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html), with a retention period of 10 years.