### PR TITLE
OTP Email

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          submodules: "recursive"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -90,3 +92,22 @@ jobs:
             startsWith(github.ref, 'refs/tags/') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Extract metadata (tags, labels) for Docker (Email OTP)
+        id: meta-eotp
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-eotp
+
+      - name: Build and push (Email OTP)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./container
+          file: ./container/Dockerfile.eotp
+          build-args: BASE_IMAGE=${{ steps.meta.outputs.tags }}
+          platforms: ${{ env.PLATFORMS }}
+          push: >
+            ${{ github.ref == format('refs/heads/{0}', env.PUBLISH_BRANCH) ||
+            startsWith(github.ref, 'refs/tags/') }}
+          tags: ${{ steps.meta-eotp.outputs.tags }}
+          labels: ${{ steps.meta-eotp.outputs.labels }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "container/keycloak-2fa-email-authenticator"]
+	path = container/keycloak-2fa-email-authenticator
+	url = https://github.com/mesutpiskin/keycloak-2fa-email-authenticator.git

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ aws ecr get-login-password --region REGION | podman login --username AWS --passw
 podman push ACCOUNT_ID.dkr.ecr.REGION.amazonaws.com/example/keycloak:YYYY-MM-DD
 ```
 
+## Email-based OTP
+
+A second container is also available (`ecs-keycloak-eotp`) which supports email-based OTP using [keycloak-2fa-email-authenticator](https://github.com/mesutpiskin/keycloak-2fa-email-authenticator).
+
 ## Deployment
 
 Import a HTTPS certificate to ACM.

--- a/container/Dockerfile.eotp
+++ b/container/Dockerfile.eotp
@@ -1,0 +1,12 @@
+ARG BASE_IMAGE=quay.io/keycloak/keycloak:latest
+
+FROM maven:3.9-eclipse-temurin-21-alpine AS otp-build
+
+COPY keycloak-2fa-email-authenticator/ /otp-email/
+RUN cd /otp-email && \
+    mvn clean package
+
+FROM $BASE_IMAGE AS target
+
+COPY --from=otp-build /otp-email/target/keycloak-2fa-email-authenticator*.jar /opt/keycloak/providers/
+RUN /opt/keycloak/bin/kc.sh build


### PR DESCRIPTION
Built as a separate container so that it appears as a separate release in GitHub, just in case others are using this repo for their Keycloak and don't want email-based OTP.